### PR TITLE
Bugfix/import order and title serializer and views

### DIFF
--- a/api_yamdb/api/serializers.py
+++ b/api_yamdb/api/serializers.py
@@ -1,4 +1,4 @@
-from api.validators import validate_year
+
 from django.conf import settings
 from django.contrib.auth.tokens import default_token_generator
 from django.core.mail import send_mail
@@ -6,12 +6,11 @@ from django.core.validators import RegexValidator
 from django.shortcuts import get_object_or_404
 from rest_framework import serializers
 
-from api.validators import validate_score_range
+from api_yamdb import constants
+from api.validators import validate_score_range, validate_year
 from reviews.models import Comment, Review
 from titles.models import Category, Genre, Title
 from users.models import User
-
-from api_yamdb import constants
 
 
 class SignUpSerializer(serializers.Serializer):

--- a/api_yamdb/api/serializers.py
+++ b/api_yamdb/api/serializers.py
@@ -13,6 +13,14 @@ from titles.models import Category, Genre, Title
 from users.models import User
 
 
+class ReadOnlyModelSerializer(serializers.ModelSerializer):
+    def get_fields(self):
+        fields = super().get_fields()
+        for field in fields.values():
+            field.read_only = True
+        return fields
+    
+
 class SignUpSerializer(serializers.Serializer):
     email = serializers.EmailField(
         required=True,
@@ -123,7 +131,7 @@ class GenreSerializer(serializers.ModelSerializer):
         exclude = ('id',)
 
 
-class TitleGETSerializer(serializers.ModelSerializer):
+class TitleGETSerializer(ReadOnlyModelSerializer):
     """Сериализатор объектов модели Title для GET запросов."""
 
     genre = GenreSerializer(many=True)
@@ -140,10 +148,6 @@ class TitleGETSerializer(serializers.ModelSerializer):
             'genre',
             'category',
             'rating',
-        )
-        read_only_fields = (
-            'genre',
-            'category',
         )
 
 

--- a/api_yamdb/api/serializers.py
+++ b/api_yamdb/api/serializers.py
@@ -139,11 +139,11 @@ class TitleGETSerializer(serializers.ModelSerializer):
             'description',
             'genre',
             'category',
-            'rating'
+            'rating',
         )
         read_only_fields = (
             'genre',
-            'category'
+            'category',
         )
 
 
@@ -155,11 +155,11 @@ class TitleSerializer(serializers.ModelSerializer):
         queryset=Genre.objects.all(),
         many=True,
         required=True,
-        allow_empty=False
+        allow_empty=False,
     )
     category = serializers.SlugRelatedField(
         slug_field='slug',
-        queryset=Category.objects.all()
+        queryset=Category.objects.all(),
     )
     year = serializers.IntegerField(validators=[validate_year])
 
@@ -170,7 +170,7 @@ class TitleSerializer(serializers.ModelSerializer):
             'year',
             'description',
             'genre',
-            'category'
+            'category',
         )
 
     def to_representation(self, title):
@@ -180,7 +180,7 @@ class TitleSerializer(serializers.ModelSerializer):
 class CommentSerializer(serializers.ModelSerializer):
     author = serializers.SlugRelatedField(
         read_only=True,
-        slug_field='username'
+        slug_field='username',
     )
 
     class Meta:

--- a/api_yamdb/api/views.py
+++ b/api_yamdb/api/views.py
@@ -15,7 +15,6 @@ from titles.models import Category, Genre, Title
 from users.models import User
 from users.permissions import (IsAdmin, IsAdminOrReadOnly,
                                IsAuthorModeratorAdminOrReadOnly)
-
 from .filters import TitleFilter
 from .serializers import (CategorySerializer, CommentSerializer,
                           GenreSerializer, ReviewSerializer, SignUpSerializer,


### PR DESCRIPTION
Правка была в следующих файлах:

api_yamdb/api_yamdb/api/serializers.py
api_yamdb/api_yamdb/api/validators.py
и в следующих частях кода:
Порядок импорта
"Висячие" запятые
TitleGETSerializer (ReadOnlySerializator)

По соответствующим комментариям от ревьюера