### PR TITLE
In TitleViewSet add filter_backends, add orderind_fields

### DIFF
--- a/api_yamdb/api/serializers.py
+++ b/api_yamdb/api/serializers.py
@@ -19,7 +19,7 @@ class ReadOnlyModelSerializer(serializers.ModelSerializer):
         for field in fields.values():
             field.read_only = True
         return fields
-    
+
 
 class SignUpSerializer(serializers.Serializer):
     email = serializers.EmailField(

--- a/api_yamdb/api/views.py
+++ b/api_yamdb/api/views.py
@@ -1,8 +1,9 @@
 from http import HTTPStatus
 
-from django.shortcuts import get_object_or_404
 from django.db.models import Avg
-from rest_framework import mixins, pagination, views, viewsets
+from django.shortcuts import get_object_or_404
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import filters, mixins, pagination, views, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import SearchFilter
 from rest_framework.permissions import (AllowAny, IsAuthenticated,
@@ -15,6 +16,7 @@ from titles.models import Category, Genre, Title
 from users.models import User
 from users.permissions import (IsAdmin, IsAdminOrReadOnly,
                                IsAuthorModeratorAdminOrReadOnly)
+
 from .filters import TitleFilter
 from .serializers import (CategorySerializer, CommentSerializer,
                           GenreSerializer, ReviewSerializer, SignUpSerializer,
@@ -47,9 +49,16 @@ class TitleViewSet(viewsets.ModelViewSet):
     queryset = Title.objects.all().order_by('name')
     permission_classes = (IsAdminOrReadOnly,)
     pagination_class = pagination.LimitOffsetPagination
+    filter_backends = (
+        DjangoFilterBackend,
+        filters.OrderingFilter,
+        filters.SearchFilter,
+    )
     filterset_class = TitleFilter
-    filterset_fields = ('name',)
+    filterset_fields = ('name', 'category', 'genre', 'year')
+    ordering_fields = ('name', 'year', 'rating')
     ordering = ('name',)
+
     http_method_names = ('get', 'post', 'patch', 'delete')
 
     def get_queryset(self):


### PR DESCRIPTION
Правка была в следующих файлах:
api_yamdb/api_yamdb/api/serializers.py
api_yamdb/api_yamdb/api/views.py

в коде TitleViewSet по замечаниям ревьюера:
указать все необходимые filter_backends
для сортировки использовать ordering_fields
расширить поля сортировки: добавить год и рейтинг

в serializers.py убрал пробелы в пустой строке