### PR TITLE
Add read_only for all fields in TitleGETSerializer, deleted ReadOnlySerializer

### DIFF
--- a/api_yamdb/api/serializers.py
+++ b/api_yamdb/api/serializers.py
@@ -12,14 +12,6 @@ from titles.models import Category, Genre, Title
 from users.models import User
 
 
-class ReadOnlyModelSerializer(serializers.ModelSerializer):
-    def get_fields(self):
-        fields = super().get_fields()
-        for field in fields.values():
-            field.read_only = True
-        return fields
-
-
 class SignUpSerializer(serializers.Serializer):
     email = serializers.EmailField(
         required=True,
@@ -133,7 +125,7 @@ class GenreSerializer(serializers.ModelSerializer):
         exclude = ('id',)
 
 
-class TitleGETSerializer(ReadOnlyModelSerializer):
+class TitleGETSerializer(serializers.ModelSerializer):
     """Сериализатор объектов модели Title для GET запросов."""
 
     genre = GenreSerializer(many=True)
@@ -151,6 +143,9 @@ class TitleGETSerializer(ReadOnlyModelSerializer):
             'category',
             'rating',
         )
+        extra_kwargs = {
+            field: {'read_only': True} for field in model._meta.fields
+        }
 
     def get_rating(self, obj):
         if hasattr(obj, 'rating'):

--- a/api_yamdb/api/serializers.py
+++ b/api_yamdb/api/serializers.py
@@ -136,8 +136,7 @@ class TitleGETSerializer(serializers.ModelSerializer):
         model = Title
         fields = ('id', 'name', 'year', 'description', 'genre', 'category',
                   'rating')
-        read_only_fields = ('id', 'name', 'year', 'description', 'genre',
-                            'category', 'rating')
+        read_only_fields = fields
 
     def get_rating(self, obj):
         if hasattr(obj, 'rating'):

--- a/api_yamdb/api/serializers.py
+++ b/api_yamdb/api/serializers.py
@@ -134,18 +134,10 @@ class TitleGETSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Title
-        fields = (
-            'id',
-            'name',
-            'year',
-            'description',
-            'genre',
-            'category',
-            'rating',
-        )
-        extra_kwargs = {
-            field: {'read_only': True} for field in model._meta.fields
-        }
+        fields = ('id', 'name', 'year', 'description', 'genre', 'category',
+                  'rating')
+        read_only_fields = ('id', 'name', 'year', 'description', 'genre',
+                            'category', 'rating')
 
     def get_rating(self, obj):
         if hasattr(obj, 'rating'):


### PR DESCRIPTION
Изменения в файле api/serializer.py в class TitleGETSerializer в соответствии с замечаниями ревьюера:
1. Указал, что все поля являются полями для чтения.
2. Удалил неиспользуемый сериализатор ReadOnlySerializer.