### PR TITLE
Add allow_null=False in genre in TitleSerializer

### DIFF
--- a/api_yamdb/api/serializers.py
+++ b/api_yamdb/api/serializers.py
@@ -166,6 +166,7 @@ class TitleSerializer(serializers.ModelSerializer):
         many=True,
         required=True,
         allow_empty=False,
+        allow_null=False,
     )
     category = serializers.SlugRelatedField(
         slug_field='slug',


### PR DESCRIPTION
Изменения в файле api/serializers.py 
1. Запретил передачу пустого жанра, т.е параметра со значением null.